### PR TITLE
Use netgo for static link

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         go env
         go version
-        go build -ldflags='-s -w' -o tftp-now-${{ matrix.os }}-${{ matrix.GOARCH }}${{ matrix.os == 'windows' && '.exe' || '' }} .
+        go build -tags netgo -ldflags='-s -w' -o tftp-now-${{ matrix.os }}-${{ matrix.GOARCH }}${{ matrix.os == 'windows' && '.exe' || '' }} .
     - name: Upload Release Asset
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #4. The Linux x86 binary, which is the native environment of the GitHub Actions VM, was compiled with `netcgo` that relies on the external libc on the rootfs. tftp-now is now built with the pure-Go `netgo` for statically-linked binaries.

Now it runs on musl libc environments!