### PR TITLE
Act as server by default when the program name is "tftp-now-serve".

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         go env
         go version
-        go build -ldflags='-s -w' -o tftp-now-${{ matrix.os }}-${{ matrix.GOARCH }}${{ matrix.os == 'windows' && '.exe' || '' }} .
+        go build -tags netgo -ldflags='-s -w' -o tftp-now-${{ matrix.os }}-${{ matrix.GOARCH }}${{ matrix.os == 'windows' && '.exe' || '' }} .
     - name: Upload Release Asset
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I would like to add a modification to act as server when the program name contains "serve". This modification may be helpful to bring up a server instantly by just double click the (renamed) executable (especially in Windows environment).

// Please feel free to throw away the code since I understand that my code change is a bit dirty.